### PR TITLE
Android audio track

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,7 @@ var styles = StyleSheet.create({
 * [selectedTextTrack](#selectedtexttrack)
 * [selectedVideoTrack](#selectedvideotrack)
 * [source](#source)
+* [alternativeAudioSource](#alternativeAudioSource)
 * [stereoPan](#stereopan)
 * [textTracks](#texttracks)
 * [useTextureView](#usetextureview)
@@ -738,6 +739,10 @@ Sets the media source. You can pass an asset loaded via require or an object wit
 
 The docs for this prop are incomplete and will be updated as each option is investigated and tested.
 
+#### alternativeAudioSource
+Sets the audio to be played with the video, as an alternative. Use this if you have trouble selecting another audio track on iOS. You can pass an asset loaded via require or an object with a uri, as in `source`.
+
+Platforms: iOS
 
 ##### Asset loaded via require
 

--- a/README.md
+++ b/README.md
@@ -326,6 +326,7 @@ var styles = StyleSheet.create({
 * [alternativeAudioSource](#alternativeAudioSource)
 * [stereoPan](#stereopan)
 * [textTracks](#texttracks)
+* [audioTracks](#audiotracks)
 * [useTextureView](#usetextureview)
 * [volume](#volume)
 
@@ -803,6 +804,42 @@ Adjust the balance of the left and right audio channels.  Any value between –1
 * **1.0** - Full right
 
 Platforms: Android MediaPlayer
+
+
+#### audioTracks
+Load one or more custom audio tracks. This takes an array of objects representing each track. Each object should have the format:
+
+Property | Description
+--- | ---
+title | Descriptive name for the track
+language | 2 letter [ISO 639-1 code](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) representing the language
+type | audio/mp4a-latm
+uri | URL for the audio track. mp3 ect.
+
+Note: Just working on Android. If you use custom audio on IOS you can use alternativeAudioSource.
+
+Example:
+```
+
+textTracks={[
+  {
+    title: "English CC",
+    language: "en",
+    type: "audio/mp4a-latm"
+    uri: "http://webaudioapi.com/samples/audio-tag/chrono.mp3"
+  },
+  {
+    title: "Turkish CC",
+    language: "tr",
+    type: "audio/mp4a-latm"
+    uri: "http://webaudioapi.com/samples/audio-tag/chrono.mp3"
+  },
+]}
+```
+
+
+Platforms: Android ExoPlayer
+
 
 #### textTracks
 Load one or more "sidecar" text tracks. This takes an array of objects representing each track. Each object should have the format:

--- a/Video.js
+++ b/Video.js
@@ -239,8 +239,10 @@ export default class Video extends Component {
   render() {
     const resizeMode = this.props.resizeMode;
     const source = resolveAssetSource(this.props.source) || {};
+    const alternativeAudioSource = resolveAssetSource(this.props.alternativeAudioSource) || {};
     const shouldCache = !Boolean(source.__packager_asset)
 
+    let alternativeAudioURI = alternativeAudioSource.uri || '';
     let uri = source.uri || '';
     if (uri && uri.match(/^\//)) {
       uri = `file://${uri}`;
@@ -271,6 +273,7 @@ export default class Video extends Component {
       style: [styles.base, nativeProps.style],
       resizeMode: nativeResizeMode,
       src: {
+        alternativeAudioURI,
         uri,
         isNetwork,
         isAsset,

--- a/Video.js
+++ b/Video.js
@@ -420,6 +420,14 @@ Video.propTypes = {
       language: PropTypes.string.isRequired
     })
   ),
+  audioTracks: PropTypes.arrayOf(
+    PropTypes.shape({
+      title: PropTypes.string,
+      uri: PropTypes.string.isRequired,
+      type: PropTypes.string,
+      language: PropTypes.string.isRequired
+    })
+  ),
   paused: PropTypes.bool,
   muted: PropTypes.bool,
   volume: PropTypes.number,

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
@@ -36,6 +36,7 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     private static final String PROP_SELECTED_TEXT_TRACK_TYPE = "type";
     private static final String PROP_SELECTED_TEXT_TRACK_VALUE = "value";
     private static final String PROP_TEXT_TRACKS = "textTracks";
+    private static final String PROP_AUDIO_TRACKS = "audioTracks";
     private static final String PROP_PAUSED = "paused";
     private static final String PROP_MUTED = "muted";
     private static final String PROP_VOLUME = "volume";
@@ -196,6 +197,12 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     public void setPropTextTracks(final ReactExoplayerView videoView,
                                   @Nullable ReadableArray textTracks) {
         videoView.setTextTracks(textTracks);
+    }
+
+    @ReactProp(name = PROP_AUDIO_TRACKS)
+    public void setPropAudioTracks(final ReactExoplayerView videoView,
+                                  @Nullable ReadableArray audioTracks) {
+        videoView.setAudioTracks(audioTracks);
     }
 
     @ReactProp(name = PROP_PAUSED, defaultBoolean = false)

--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -418,7 +418,7 @@ static int const RCTVideoUnset = -1;
   return nil;
 }
 
-- (void)playerItemPrepareText:(AVAsset *)asset assetOptions:(NSDictionary * __nullable)assetOptions withCallback:(void(^)(AVPlayerItem *))handler
+- (void)playerItemPrepareText:(AVAsset *)asset assetOptions:(NSDictionary * __nullable)assetOptions withCallback:(void(^)(AVPlayerItem *))handler withAudio:(AVAsset *)audio
 {
   // AVPlayer can't airplay AVMutableCompositions
   _allowsExternalPlayback = NO;


### PR DESCRIPTION
I've added the possibility to use custom audioTracks on android part. As you know that you cant add custom audio track in code part on Android. You just select audio track that whit in video chanel. But I have need custom mp3 file add in code part. So in IOS part @reime005 done it by using **alternativeAudioSource**. Thanks a lot for that. Developed android part by using audioTracks props by me. Now You can add custom audio file in array like textTracks. So just add like this: 

```
 audioTracks={[
              {
                language: 'en',
                title: 'English CC',
                type: 'audio/mp4a-latm',
                uri: "http://webaudioapi.com/samples/audio-tag/chrono.mp3"
              },
              {
                language: 'en',
                title: 'English CC',
                type: 'audio/mp4a-latm',
                uri: "https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3"
              }
            ]}
```

In summary, You can use _alternativeAudioSource_ for custom audio in IOS and you can use audioTracks in Android.

instalition with yarn:
`yarn add  yasinugrl/react-native-video#androidAudioTrack`

with npm:
`npm i reime005/react-native-video#audioTrack --save`